### PR TITLE
Remove section on "How does licensing work"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,13 +56,6 @@
 			a process of delving deep into the many layers of the engine and modernizing, refactoring, refining
 			and demolishing various sections. So, we felt the analogy to geology and mining was apt!
 		</p>
-		<h2>How do I use Strata for my licensed project?</h2>
-		<p>
-			All contributors to Strata Source must have licensed access to CS:GO's branch of Source 1 from Valve.
-			We are happy for developers to use our code in any way they see fit, but to gain access you must have
-			a valid license (NDA) from Valve. We have no say whatsoever in who gets licensed, nor can we offer
-			any kind of legal advice in order to be licensed.
-		</p>
 		<h2>Why not Source 2?</h2>
 		<p>
 			Elephant in the room: we don't have access to Source 2! So far Source 2 has had a limited


### PR DESCRIPTION
This info is not necessary.