### PR TITLE
Layout simplification, updated FAQ

### DIFF
--- a/src/lib/components/MainContainer.svelte
+++ b/src/lib/components/MainContainer.svelte
@@ -9,7 +9,6 @@
 		grid-template-columns: 1fr auto;
 		width: calc(100% - 50px);
 		max-width: 1140px;
-		padding-block: 2rem;
 		align-items: center;
 	}
 </style>

--- a/src/routes/(components)/PageHeader.svelte
+++ b/src/routes/(components)/PageHeader.svelte
@@ -15,15 +15,6 @@
 
 <header>
 	<MainContainer>
-		<div class="logo-wrapper">
-			<a href="/">
-				<img
-					src="https://branding.stratasource.org/i/strata-source/logo/ondark/color.svg"
-					alt="Strata Source Logo"
-				/>
-			</a>
-		</div>
-
 		<button class="menu-opener" on:click={() => (nav = !nav)}>
 			<span bind:this={navIcon} class="mdi" class:mdi-menu={!nav} class:mdi-close={nav} />
 		</button>
@@ -47,8 +38,8 @@
 </header>
 
 <style lang="scss">
-	.logo-wrapper {
-		width: fit-content;
+	header {
+		padding: 2rem;
 	}
 
 	img {
@@ -56,7 +47,7 @@
 	}
 
 	.menu-opener {
-		font-size: 1rem;
+		margin-left: auto;
 		color: white;
 		background: none;
 		border: none;
@@ -68,6 +59,7 @@
 
 	nav {
 		display: flex;
+		justify-content: right;
 		gap: 1rem;
 
 		& .socials {
@@ -97,6 +89,10 @@
 	}
 
 	@media only screen and (max-width: 700px) {
+		header {
+			padding: 1rem 0 1rem 0;
+		}
+		
 		.menu-opener {
 			display: block;
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,89 +47,75 @@
 </div>
 
 <div id="faq" class="faq">
-	<div class="title">
-		FAQ
-		<span class="tint" aria-hidden="true">FAQ</span>
-		<span aria-hidden="true">FAQ</span>
-	</div>
-	<div class="content">
-		<h2>What is Strata Source?</h2>
-		<p>
-			Strata Source began as the Source Engine branch behind Portal 2: Community Edition (P2:CE) in
-			2020. In late 2020, Momentum Mod joined forces with the P2:CE team with the goal of
-			collaborating on this new branch. Today, a team of almost two dozen developers contribute to
-			Strata Source, with three licensed projects using the engine.
-		</p>
-		<p>
-			Source is a closed-source engine, and historically speaking Source 1 game developers have been
-			isolated from one another. This has led to a lot of overlapping work, which is especially
-			unfortunate given that we're typically not-for-profit projects, working in our free time.
-			The aim of Strata is to foster more open communication between licensed projects and share engine
-			changes where possible. To be clear, we <i>only</i> work with existing licensees.
-		</p>
-		<h2>We have nothing to do with Source licensing.</h2>
-		<p>
-			This isn't a question, we just want to make it 100% clear. Valve provide a very clear
-			explanation of the Source 1 licensing situation <a
-				href="https://partner.steamgames.com/doc/sdk/uploading/distributing_source_engine"
-				>on the Steamworks documentation</a
-			>, we don't have anything to add. We have no say whatsoever in who gets licensed, nor can we
-			offer any kind of advice (legal or otherwise) related to licensing.
-		</p>
-		<h2>Why not Source 2?</h2>
-		<p>
-			Elephant in the room: we don't have access to Source 2! So far Source 2 has had a limited
-			release without a public code SDK, and <a
-				href="https://twitter.com/phys_ballsocket/status/1616204680979222528?s=20"
-				>we have no idea what Valve's plans are in the future.</a
-			>
-			If we did have access we'd certainly evaluate it, but it's not immediately certain whether P2:CE
-			or Momentum could practically be able to, or even want to switch.
-		</p>
-		<p>
-			Source 2 introduces a new engine infrastructure and new physics library that could negatively
-			impact the game feel that players are used to with Source 1. While having access to both
-			Source 1 and 2 would help us fix this, this would be a monumental effort from developers to
-			get right.
-		</p>
-		<p>
-			Momentum Mod and P2:CE build on a large amount of existing Source 1 content. There are
-			thousands of maps, models, textures, and other assets that we want to maintain compatibility
-			with. In addition, Source 1 has tried-and-tested tooling workflow, in particular Hammer.
-			Source 2 doesn't currently support Source 1 assets or the aforementioned workflow, so moving
-			to Source 2 would be a monumental effort for creators as well.
-		</p>
-		<p>
-			We already make use of some modern Valve technologies, some of which are from Source 2. For
-			example, we have access to Valve's Panorama UI framework, originally for Source 2 but
-			backported to Source 1 for CS:GO, and have gotten an enormous amount of use out of it.
-		</p>
-		<p>
-			Source 2 is clearly modernized and the engine has a lot of impressive features, but we have
-			a sincere interest in the long-term maintenance of Source 1. There are numerous places where
-			more modern technologies can be implemented, the engine and its many bugs can be refined, and
-			piles of tech-debt to extract and demolish; we think this is a worthwhile endeavor!
-		</p>
-
-		<h2>Where does your name come from?</h2>
-		<p>
-			The name <em>Strata</em> comes from geology, referring to the rocky layers of a planet's crust.
-			The Source Engine is a huge codebase containing decades worth of code, from contemporary titles
-			such as CS:GO and Portal 2, going all the way back to the days of Quake. The engine therefore consists
-			of many layers of systems and features, and with it, many layers of tech debt. Our work is frequently
-			a process of delving deep into the many layers of the engine and modernizing, refactoring, refining
-			and demolishing various sections. So, we felt the analogy to geology and mining was apt!
-		</p>
-
-		<h2>Wasn't your previous name “Chaos”?</h2>
-		<p>
-			Yep! When the project started in 2020 it was under the name “Chaos Source” with contributors
-			organized under the umbrella of “Chaos Initiative” and the P2:CE team known as “Chaos
-			Studios”. This naming was chosen in very early days of the project, and while it was okay for
-			a time, in 2023 we decided to optimize our branding with input from a wider range of project
-			members and decided on <strong>Strata Source</strong>.
-		</p>
-	</div>
+	<h2>What is Strata Source?</h2>
+	<p>
+		Strata Source began as the Source Engine branch behind Portal 2: Community Edition (P2:CE) in
+		2020. In late 2020, Momentum Mod joined forces with the P2:CE team with the goal of
+		collaborating on this new branch. The aim of Strata is to foster collaboration between licensed
+		projects. Today, a team of almost two dozen developers contribute to Strata Source, with three
+		licensed projects using the engine.
+	</p>
+	<h2>How can I use Strata?</h2>
+	<p>
+		Strata is only accessible as part of the licensed games built using it; we do not provide any
+		publicly available SDK. Any licensed Source engine project is welcome to contact us regarding
+		collaboration.
+	</p>
+	<p>
+		If you’re interested in making a Portal 2 mod on Strata, check out <a
+			href="https://portal2communityedition.com/">P2:CE</a
+		>
+		or <a href="https://www.portalrevolution.com/">Portal: Revolution.</a>
+	</p>
+	<h2>Can Strata Help my Project Get Licensed?</h2>
+	<p>
+		<b>No.</b> Licensing is done entirely by Valve. We cannot license projects and don’t provide any
+		source code to unlicensed projects. We cannot influence Valve’s licensing decisions and don’t
+		offer legal advice. See Valve’s documentation on Source engine licensing:
+		<a href="https://partner.steamgames.com/doc/sdk/uploading/distributing_source_engine"
+			>Distributing Source Engine Games / Mods</a
+		>.
+	</p>
+	<h2>Can I use Strata’s Logo or Branding?</h2>
+	<p>
+		Please don’t use our logo or branding to represent your project. <!--If you are developing a P2:CE mod, see their guidelines on using P2:CE branding (LINK HERE).-->
+	</p>
+	<p>
+		You are welcome to use our logo and branding in material about Strata itself, such as videos or
+		articles. See our branding page: <a href="https://stratasource.org/branding">Strata Branding</a
+		>.
+	</p>
+	<h2>Why not Source 2?</h2>
+	<p>
+		We do not have access to Source 2 and are not licensed to use Source 2. All of the games
+		currently using Strata are closely tied to existing Source 1 content, so Source 2 would be a
+		poor choice for us.
+	</p>
+	<p>
+		We do have some Source 2 features, such as the Panorama UI system, that were backported by Valve
+		to CS:GO. However, Strata is still almost entirely Source 1. Whilst Source 1 does contain
+		considerable tech-debt, we’ve been able to improve and modernize it considerably, and we think its
+		long-term maintenance is a worthwhile endeavor.
+	</p>
+	<h2>Where does your name come from?</h2>
+	<p>
+		The name <em>Strata</em> comes from geology, referring to the rocky layers of a planet's crust. The
+		Source Engine is a huge codebase containing decades worth of code, from contemporary titles such
+		as CS:GO and Portal 2, going all the way back to the days of Quake.
+	</p>
+	<p>
+		Our work is frequently a process of delving deep into the many layers of the engine and
+		modernizing, refactoring, refining and demolishing various sections. So, we felt the analogy to
+		geology and mining was apt!
+	</p>
+	<h2>Wasn't your previous name “Chaos”?</h2>
+	<p>
+		Yep! When the project started in 2020 it was under the name “Chaos Source” with contributors
+		organized under the umbrella of “Chaos Initiative” and the P2:CE team known as “Chaos Studios”.
+		This naming was chosen in very early days of the project, and while it was okay for a time, in
+		2023 we decided to optimize our branding with input from a wider range of project members and
+		decided on Strata Source.
+	</p>
 </div>
 
 <style lang="scss">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,16 +16,10 @@
 <Meta description="Introducing Strata Source, a game changer for Source modding" />
 
 <div class="hero">
-	<div class="text">
-		<h1>Introducing<br />Strata Source</h1>
-		<p>
-			A community-made branch of the Source engine emphasing modern features and development
-			practices
-		</p>
-	</div>
-	<div class="graphics">
-		<div class="portal2-background" />
-	</div>
+	<img
+		src="https://branding.stratasource.org/i/strata-source/logo/ondark/color.svg"
+		alt="Strata Source Logo"
+	/>
 </div>
 
 <div class="games">
@@ -141,126 +135,41 @@
 <style lang="scss">
 	.hero {
 		grid-column: 1 / -1;
-		display: grid;
-		grid-template-columns: 1fr 1fr;
+		display: flex;
 		gap: 50px;
 		align-items: center;
-		min-height: 60vh;
+		justify-content: center;
+		padding: 2rem 0;
 
-		& .text {
-			display: flex;
-			flex-direction: column;
-			gap: 15px;
-
-			& h1 {
-				font-size: 48px;
-			}
-			& p {
-				font-size: 20px;
-				color: rgba(255, 255, 255, 0.4);
-				line-height: 1.5em;
-			}
-		}
-
-		& .graphics {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-
-			& .portal2-background {
-				width: 80%;
-				height: 80%;
-				background: url('$lib/images/backgrounds/blend.jpg');
-				background-position: center;
-				background-size: cover;
-				aspect-ratio: 1 / 1;
-				-webkit-mask-image: url('https://branding.stratasource.org/i/strata/icon/ondark/mono.svg');
-				-webkit-mask-repeat: no-repeat;
-				-webkit-mask-position: center;
-				mask-image: url('https://branding.stratasource.org/i/strata/icon/ondark/mono.svg');
-				mask-repeat: no-repeat;
-				mask-position: center;
-			}
+		> img {
+			width: 50%;
 		}
 	}
 
 	.games {
-		padding-top: 2rem;
+		margin-top: 2rem;
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;
 		gap: 0.5rem;
 	}
 
 	.faq {
-		$padding-inline: 6rem;
-		$polygon-height: 2rem;
-		$title-offset: 3rem;
 		grid-column: 1 / -1;
-		margin-top: 12rem;
+		margin-top: 1rem;
 		margin-bottom: 2rem;
-		width: 80%;
 		margin-inline: auto;
-		padding-inline: $padding-inline;
-		padding-bottom: 3rem;
-		position: relative;
-		font-size: 1.1em;
-
-		&::before {
-			content: '';
-			position: absolute;
-			z-index: -1;
-			inset: 0;
-			background-color: #a32b2b;
-			clip-path: polygon(0 $polygon-height, 100% 0, 100% 100%, 0 100%);
-		}
-
-		& .title {
-			font-weight: 1000;
-			font-size: 8rem;
-			transform: translateY(#{-$title-offset});
-			margin-bottom: -$title-offset;
-			color: transparent;
-
-			& > * {
-				position: absolute;
-				inset: 0;
-			}
-
-			& span {
-				color: white;
-				pointer-events: none;
-				user-select: none;
-
-				&:not(.tint) {
-					clip-path: polygon(
-						0 0,
-						100% 0,
-						calc(100% + #{$padding-inline}) $title-offset,
-						-$padding-inline $title-offset + $polygon-height
-					);
-				}
-
-				&.tint {
-					color: rgb(236, 174, 174);
-				}
-			}
-		}
 
 		& h2 {
-			font-size: 2.5rem;
-			margin-top: 3rem;
-			margin-bottom: 1rem;
-			margin-inline: 4rem;
-			text-align: center;
+			color: #f0413c;
+			font-size: 2rem;
+			margin-top: 2.5rem;
 		}
 
 		& p {
-			font-size: 1.1rem;
-			margin: 1rem 0;
+			margin: 0.5rem 0;
 			font-weight: 300;
 			line-height: 1.4rem;
 			text-align: justify;
-			text-indent: 0.5rem;
 		}
 
 		& a {
@@ -271,13 +180,10 @@
 
 	@media only screen and (max-width: 768px) {
 		.hero {
-			grid-template-columns: 1fr;
-			gap: 16px;
+			padding: 0 0 1rem 0;
 
-			& .graphics {
-				& .portal2-background {
-					max-height: 300px;
-				}
+			img {
+				width: 100%;
 			}
 		}
 
@@ -287,39 +193,11 @@
 
 		.faq {
 			width: 100%;
-			margin-top: 8rem;
 			margin-bottom: 0;
-			padding-bottom: 1rem;
-
-			$padding-inline: 1rem;
-			$polygon-height: 1.5rem;
-			$title-offset: 3.5rem;
-
-			padding-inline: $padding-inline;
-
-			&::before {
-				clip-path: polygon(0 $polygon-height, 100% 0, 100% 100%, 0 100%);
-			}
-
-			& .title {
-				$offset: 3rem;
-				transform: translateY(#{-$title-offset});
-				margin-bottom: -$title-offset;
-
-				& span:not(.tint) {
-					clip-path: polygon(
-						0 0,
-						100% 0,
-						calc(100% + #{$padding-inline}) $title-offset,
-						-$padding-inline $title-offset + $polygon-height
-					);
-				}
-			}
+			padding-bottom: 0;
 
 			& h2 {
 				font-size: 2rem;
-
-				margin-inline: 1rem;
 			}
 
 			& p {


### PR DESCRIPTION
Removes the hero section of the site and simplifies the FAQ layout, to deliberately look drier and less marketing-y.

Also updates FAQ content to use stuff in the google doc we were working on yesterday.

Desktop (1920 x 1080) and mobile (412 x 915) screenshots:
![localhost_5173_(screen lol)](https://github.com/user-attachments/assets/9924ec0f-fc2a-434d-a2ae-5908436bc0c6)
![localhost_5173_(Pixel 7)](https://github.com/user-attachments/assets/6aacc002-7551-45b0-9a75-944baac2bc89)
